### PR TITLE
Add media query based dark theme switch to example basic-vue-cli

### DIFF
--- a/examples/basic-vue-cli/src/styles/theme.scss
+++ b/examples/basic-vue-cli/src/styles/theme.scss
@@ -1,4 +1,16 @@
-@use '@material/theme'  with (
+$dark-mode-primary: #67360b;
+$dark-mode-on-primary: white;
+
+@use '~@material/theme'  with (
   $primary: #be6c35,
   $on-primary: white,
 );
+
+:root {
+    @media screen and (prefers-color-scheme: dark) {
+        --mdc-theme-primary: #{$dark-mode-primary};
+        --mdc-theme-on-primary: #{$dark-mode-on-primary};
+
+        background: #291202;
+    }
+}


### PR DESCRIPTION
I finally found a very simple way to achieve dark mode theming in Material using just CSS and media queries. All it's needed is to target Material custom CSS properties accordingly. 

For reasons I didn't care to investigate, custom properties starting with `--` were not compiling when using variables, but work fine with interpolation.

This PR adds just enough to `basic-vue-example` to give others a starting point.