### PR TITLE
fix: ensures mcw-tab-bar uses the corrent rootEl

### DIFF
--- a/packages/tabs/tab.js
+++ b/packages/tabs/tab.js
@@ -121,7 +121,7 @@ export default {
     };
 
     onMounted(() => {
-      rootEl = uiState.root.$el;
+      rootEl = (uiState.root.$el.nodeType === 3) ? uiState.root.$el.nextSibling : uiState.root.$el;
       foundation = new MDCTabFoundation(adapter);
       foundation.init();
 

--- a/packages/tabs/tab.js
+++ b/packages/tabs/tab.js
@@ -121,6 +121,8 @@ export default {
     };
 
     onMounted(() => {
+      // Quick fix to https://github.com/pgbross/vue-material-adapter/issues/178
+      // uiState.root gets set to the wrong element when "to" is set
       rootEl = (uiState.root.$el.nodeType === 3) ? uiState.root.$el.nextSibling : uiState.root.$el;
       foundation = new MDCTabFoundation(adapter);
       foundation.init();


### PR DESCRIPTION
Fixes #178

This PR fixes the symptom of the issue which happens to be: for some reason ```uiState.root``` gets set to the empty TextNode that is created before the button instead of being set to the correct root element.

It doesn't make an attempt to implement the correct fix that would be: having ```uiState.root``` to be correctly set. That would be preferable but the complexity is beyond my reach.

My suggest is that this quick fix is accepted to ensure the problem is solved while a more exhaustive search for the root cause is performed.