### PR TITLE
fix: fonts are missing in vue-cli example

### DIFF
--- a/examples/basic-vue-cli/src/styles/_index.scss
+++ b/examples/basic-vue-cli/src/styles/_index.scss
@@ -3,3 +3,6 @@
 @forward 'button';
 @forward 'snackbar';
 @forward '@material/dialog/mdc-dialog';
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
+@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500");
+@import url("https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500");


### PR DESCRIPTION
Without this fix the snackbar looks like below:
![image](https://user-images.githubusercontent.com/5149179/121884983-4415f480-cd1c-11eb-8406-9d868b13cc89.png)
