### PR TITLE
fix: ensure hoisting menu-surface adds element to body

### DIFF
--- a/src/menu/menu-surface.js
+++ b/src/menu/menu-surface.js
@@ -109,7 +109,8 @@ export default {
     };
 
     const hoistMenuToBody = () => {
-      document.body.append(uiState.root.remove());
+      uiState.root.remove();
+      document.body.append(uiState.root);
       setIsHoisted(true);
     };
 


### PR DESCRIPTION
According to [the MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/remove) the `remove()` method does not return the removed element. As the result `undefined` is passed to `append()` and nothing is added to the body.
Fixed by separating `remove()` and `append()` calls.