### PR TITLE
fix: setting menu-surface position

### DIFF
--- a/src/menu/menu-surface.js
+++ b/src/menu/menu-surface.js
@@ -79,13 +79,13 @@ export default {
         },
         setPosition: position => {
           uiState.root.style.left =
-            'left' in position ? `${position.left}px` : undefined;
+            'left' in position ? `${position.left}px` : '';
           uiState.root.style.right =
-            'right' in position ? `${position.right}px` : undefined;
+            'right' in position ? `${position.right}px` : '';
           uiState.root.style.top =
-            'top' in position ? `${position.top}px` : undefined;
+            'top' in position ? `${position.top}px` : '';
           uiState.root.style.bottom =
-            'bottom' in position ? `${position.bottom}px` : undefined;
+            'bottom' in position ? `${position.bottom}px` : '';
         },
         setMaxHeight: height => {
           uiState.root.style.maxHeight = height;


### PR DESCRIPTION
The issue is that setting style property to "undefined" doesn't reset
the current value. Because of that, depending on the current position of
the menu, it is positioned using both "top" and "bottom" properties. The
result is that menu changes its size instead of just being positioned.

Fixed by setting to empty string.